### PR TITLE
Add typescript/chrome types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "extension-seed",
+  "name": "chrome-extension-seed",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -8,6 +8,7 @@
       "version": "0.0.103",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.103.tgz",
       "integrity": "sha512-s8So1IG1fIu2dg2MRV3k6W5OjlVaJriNXIxIWDHi+Rdz5dLeuzPKcWzkVlcaVL4gONfn44JKC0RhW+P0UohLfg==",
+      "dev": true,
       "requires": {
         "@types/filesystem": "*",
         "@types/har-format": "*"
@@ -17,6 +18,7 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.29.tgz",
       "integrity": "sha512-85/1KfRedmfPGsbK8YzeaQUyV1FQAvMPMTuWFQ5EkLd2w7szhNO96bk3Rh/SKmOfd9co2rCLf0Voy4o7ECBOvw==",
+      "dev": true,
       "requires": {
         "@types/filewriter": "*"
       }
@@ -24,12 +26,14 @@
     "@types/filewriter": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.28.tgz",
-      "integrity": "sha1-wFTor02d11205jq8dviFFocU1LM="
+      "integrity": "sha1-wFTor02d11205jq8dviFFocU1LM=",
+      "dev": true
     },
     "@types/har-format": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.4.tgz",
-      "integrity": "sha512-iUxzm1meBm3stxUMzRqgOVHjj4Kgpgu5w9fm4X7kPRfSgVRzythsucEN7/jtOo8SQzm+HfcxWWzJS0mJDH/3DQ=="
+      "integrity": "sha512-iUxzm1meBm3stxUMzRqgOVHjj4Kgpgu5w9fm4X7kPRfSgVRzythsucEN7/jtOo8SQzm+HfcxWWzJS0mJDH/3DQ==",
+      "dev": true
     },
     "adm-zip": {
       "version": "0.4.14",
@@ -3296,6 +3300,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "unc-path-regex": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   },
   "author": "Pavel Gershanik",
   "license": "ISC",
-  "dependencies": {
-    "@types/chrome": "0.0.103"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@types/chrome": "0.0.103",
     "adm-zip": "^0.4.14",
     "gulp": "^4.0.2",
-    "gulp-zip": "^5.0.1"
+    "gulp-zip": "^5.0.1",
+    "typescript": "^3.8.3"
   }
 }

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,1 +1,1 @@
-console.log('aaa')
+window.chrome.runtime.onInstalled.addListener(() => console.log("Type check"));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,47 +3,21 @@
     /* Basic Options */
     "target": "ES6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     "module": "commonjs", /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation:  */
+    
+    // Uncomment for DOM (content script)
+    //"lib": ["ES2015", "DOM"],                             /* Specify library files to be included in the compilation:  */
     "allowJs": false, /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./build",                        /* Redirect output structure to the directory. */
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-    /* Strict Type-Checking Options */
     "strict": false, /* Enable all strict type-checking options. */
     "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     "strictNullChecks": true, /* Enable strict null checks. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
     /* Additional Checks */
     "noUnusedLocals": true,                /* Report errors on unused locals. */
     "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-    /* Module Resolution Options */
     "moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     "rootDirs": ["./src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [], /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    /* Source Map Options */
-    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "types": ["chrome"],
   }
 }


### PR DESCRIPTION
Same PR as https://github.com/Thalimenel/Chrome-Extension-Seed/pull/1 (Couldn't reopen)

> - Added typescript as dev dependency in ```package.json```
> - Added Chrome API types definition.
> - Added ES2015, DOM libraries